### PR TITLE
[WIP] [POC] porting -i feature of ohcount to ohcount4j

### DIFF
--- a/src/main/java/com/blackducksoftware/ohcount4j/FileCount.java
+++ b/src/main/java/com/blackducksoftware/ohcount4j/FileCount.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2016 Black Duck Software, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.blackducksoftware.ohcount4j;
+
+public class FileCount {
+    private final SourceFile source;
+    private final LanguageCount count;
+    
+    public FileCount(SourceFile source, LanguageCount count)
+    {
+        this.source = source;
+        this.count  = count;
+    }
+    
+    public SourceFile getSource()
+    {
+        return source;
+    }
+    
+    public LanguageCount getLanguage()
+    {
+        return count;
+    }
+}

--- a/src/main/java/com/blackducksoftware/ohcount4j/Files.java
+++ b/src/main/java/com/blackducksoftware/ohcount4j/Files.java
@@ -35,7 +35,7 @@ public class Files {
             LanguageCount count  = file.getLanguage();
             SourceFile    source = file.getSource();
             
-            System.out.format("%-24s %6d %10d %9.1f%% %10d %10d %s\n",
+            System.out.format("%-20s %6d %10d %9.1f%% %10d %10d %s\n",
                     count.getLanguage().niceName(),
                     count.getCode(),
                     count.getComment(),

--- a/src/main/java/com/blackducksoftware/ohcount4j/Files.java
+++ b/src/main/java/com/blackducksoftware/ohcount4j/Files.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2016 Black Duck Software, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.blackducksoftware.ohcount4j;
+
+import java.util.ArrayList;
+
+public class Files {
+    protected ArrayList<FileCount> files = new ArrayList<>();
+    
+    public Files(ArrayList<FileCount> files) {
+        this.files = files;
+    }
+    
+    public void print() {
+        System.out.format("Examining %d file(s)\n", files.size());
+        System.out.println("                            Ohloh Line Count");
+        System.out.println("Language               Code    Comment  Comment %      Blank      Total  File");
+        System.out.println("----------------  ---------  ---------  ---------  ---------  ---------  -----------------------------------------------");
+
+        for (FileCount file : files) {
+            LanguageCount count  = file.getLanguage();
+            SourceFile    source = file.getSource();
+            
+            System.out.format("%-24s %6d %10d %9.1f%% %10d %10d %s\n",
+                    count.getLanguage().niceName(),
+                    count.getCode(),
+                    count.getComment(),
+                    count.getCommentRatio() * 100.0f,
+                    count.getBlank(),
+                    count.getTotal(),
+                    source.getPath());
+        }
+    }
+}

--- a/src/main/java/com/blackducksoftware/ohcount4j/Ohcount.java
+++ b/src/main/java/com/blackducksoftware/ohcount4j/Ohcount.java
@@ -66,6 +66,8 @@ public class Ohcount {
                 annotate(files, getFilenames(files));
             } else if (opts.detect) {
                 detect(files, getFilenames(files));
+            } else if (opts.interactive) {
+                interactive(files, getFilenames(files));
             } else {
                 summarize(files, getFilenames(files));
             }
@@ -113,6 +115,10 @@ public class Ohcount {
         }
     }
 
+    static void interactive(List<File> files, List<String> filenames) throws IOException {
+        new ThreadedFileList(4).count(files, filenames).print();
+    }
+
     static void summarize(List<File> files, List<String> filenames) throws IOException {
         new ThreadedFileListCounter(4).count(files, filenames).print();
     }
@@ -143,6 +149,9 @@ public class Ohcount {
 
         @Option(name = "-l", usage = "show supported languages")
         boolean supportedLanguages = false;
+
+        @Option(name = "-i", usage = "individual files line count summary")
+        boolean interactive = false;
     }
 
 }

--- a/src/main/java/com/blackducksoftware/ohcount4j/ThreadedFileList.java
+++ b/src/main/java/com/blackducksoftware/ohcount4j/ThreadedFileList.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2016 Black Duck Software, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.blackducksoftware.ohcount4j;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+public class ThreadedFileList {
+
+    private class FileCounterCallable implements Callable<List<FileCount>> {
+        private final File         file;
+        private final List<String> filenames;
+
+        public FileCounterCallable(File file, List<String> filenames) {
+            this.file      = file;
+            this.filenames = filenames;
+        }
+
+        @Override
+        public List<FileCount> call() throws Exception {
+            try (SourceFile sourceFile = new SourceFile(file)) {
+                Count counter = new FileCounter(sourceFile, filenames).count();
+                
+                List<LanguageCount> languages = counter.getLanguageCounts();
+                List<FileCount> counts = new ArrayList<>();
+                
+                for (LanguageCount language : languages) {
+                    counts.add(new FileCount(sourceFile, language));
+                }
+                
+                return counts;
+            }
+        }
+    }
+
+    protected Count count = new Count();
+
+    private final ExecutorService pool;
+
+    public ThreadedFileList(int poolSize) {
+        pool = Executors.newFixedThreadPool(poolSize);
+    }
+
+    public Files count(List<File> files, List<String> filenames) throws IOException {
+        ArrayList<FileCount> counts                = new ArrayList<>();
+        ArrayList<Future<List<FileCount>>> futures = new ArrayList<>();
+
+        for (File file : files) {
+            futures.add(pool.submit(new FileCounterCallable(file, filenames)));
+        }
+        
+        for (Future<List<FileCount>> future : futures) {
+            try {
+                for (FileCount fileCount : future.get()) {
+                    counts.add(fileCount);
+                }
+            } catch (InterruptedException | ExecutionException e) {
+                throw new OhcountException(e);
+            }
+        }
+        
+        pool.shutdown();
+
+        return new Files(counts);
+    }
+}


### PR DESCRIPTION
This patch attempts to introduce the good 'ol `-i` feature of `ohcount` in `ohcount4j`.

To give a more precise idea of what this does:

```
∙ ./ohcount4j -i                                                                                                                                                                          14:08  ocramius@Marcos-MBP
Examining 513 file(s)
                            Ohloh Line Count
Language               Code    Comment  Comment %      Blank      Total  File
----------------  ---------  ---------  ---------  ---------  ---------  -----------------------------------------------
Rexx                         25        400      94.1%          3        428 ./build/jacoco/jacocoTest.exec
Unknown                      32          0       0.0%          1         33 ./build/one-jar-build/doc/one-jar-license.txt
Unknown                       4          0       0.0%          1          5 ./build/one-jar-build/log4j.properties
Unknown                       4          0       0.0%          1          5 ./build/one-jar-build/META-INF/MANIFEST.MF
HTML                        131          0       0.0%          0        131 ./build/reports/tests/classes/com.blackducksoftware.ohcount4j.CountListTest.html
HTML                        116          0       0.0%          0        116 ./build/reports/tests/classes/com.blackducksoftware.ohcount4j.CountTest.html
HTML                        271          0       0.0%          0        271 ./build/reports/tests/classes/com.blackducksoftware.ohcount4j.detect.DetectorTest.html
HTML                        101          0       0.0%          0        101 ./build/reports/tests/classes/com.blackducksoftware.ohcount4j.detect.EmacsModeDetectorTest.html
HTML                        111          0       0.0%          0        111 ./build/reports/tests/classes/com.blackducksoftware.ohcount4j.detect.ExtnASPXResolverTest.html
HTML                        111          0       0.0%          0        111 ./build/reports/tests/classes/com.blackducksoftware.ohcount4j.detect.ExtnASXResolverTest.html
HTML                        121          0       0.0%          0        121 ./build/reports/tests/classes/com.blackducksoftware.ohcount4j.detect.ExtnBASResolverTest.html
```

That's really all there is to it, except that I obviously need to clean up things a bit.

TODO:
- [x] clean up output alignment
- [ ] tests (I wrote none so far, but I didn't touch Java in years)
- [ ] code design review
